### PR TITLE
add theme-color support

### DIFF
--- a/code/controller/WebAppPageControllerExtension.php
+++ b/code/controller/WebAppPageControllerExtension.php
@@ -15,6 +15,22 @@ class WebAppPageControllerExtension extends Extension
         $tags .= '<meta name="apple-mobile-web-app-status-bar-style" content="'.$config->StatusBar.'">';
         $tags .= '<meta name="apple-mobile-web-app-title" content="'.$config->AppTitle.'">';
 
+        // User has defined a theme color.
+        if($config->ThemeColor) {
+
+            $color = $config->ThemeColor;
+
+            // Make sure color starts with a number sign.
+            if(substr($color,0,1) !== '#') $color = '#' . $color;
+
+            // Chrome, Firefox, Opera
+            $tags .= '<meta name="theme-color" content="' . $color . '">';
+
+            // Windows Phone
+            $tags .= '<meta name="msapplication-navbutton-color" content="' . $color . '">';
+
+        }
+        
         foreach ($icons as $icon) {
             $size = $icon->Size;
             $url = $icon->Image()->URL;

--- a/code/model/WebAppConfig.php
+++ b/code/model/WebAppConfig.php
@@ -65,6 +65,19 @@ class WebAppConfig extends DataObject implements PermissionProvider
                 singleton('WebAppConfig')->dbObject('StatusBar')->enumValues()
             )
         );
+        
+        // Support for tractorcow/silverstripe-colorpicker.
+        if(class_exists('ColorField')) {
+            $colorField = new ColorField('ThemeColor', 'Theme color');
+        } else {
+            $colorField = new TextField('ThemeColor', 'Theme color');
+            $colorField->setRightTitle('Color that will fill the status bar of the handheld device, eg. \'#4285f4\'');
+        }
+
+        $fields->addFieldToTab(
+            'Root.Config',
+            $colorField
+        );
 
         $fields->addFieldToTab('Root.Config', new LabelField('Label', 'Viewport meta options'));
         $fields->addFieldToTab(

--- a/code/model/WebAppConfig.php
+++ b/code/model/WebAppConfig.php
@@ -9,6 +9,7 @@
  * @property bool    MinimalUI      Option to use the Minimal UI (new in iOS7).
  * @property bool    UserScalable   Viewport option to disable/enable scaling of the content.
  * @property bool    Javascript     Option to use experimental javascript, the javascript is used to keep a user in the fullscreen app experience but has to be used with caution because it overrides all <a> tags includeing the links that link to external sites and the links that dont go anywhere. This is beiing worked on.
+ * @property string  ThemeColor     A theme color that will fill the status bar of a handheld device. (optional)
  *
  * @method   HasMany Icons          This module can manage multiple sorts of icons for multiple device types.
  * @method   HasMany StartupScreens This module can manage multiple sorts of splash screens for multiple device types.
@@ -28,7 +29,8 @@ class WebAppConfig extends DataObject implements PermissionProvider
         "MinimalUI" => "Varchar(255)",
         "UserScalable" => "Enum('yes,no','no')",
         //"Width" => "Enum('yes,no','no')",
-        "Javascript" => "Enum('yes,no','no')"
+        "Javascript" => "Enum('yes,no','no')",
+        "ThemeColor" => "Varchar(255)"
     );
 
     private static $has_many = array(


### PR DESCRIPTION
Hey buddy nice module! 

I added support for theme-color meta tag which allows you to define a color that will fill the status bar of the mobile device, see this for more information about how it works and looks: https://developers.google.com/web/fundamentals/design-and-ui/browser-customization/theme-color

Please have a look! :-)
